### PR TITLE
Enums creation (again)

### DIFF
--- a/gamepost/src/main/java/es/codeurjc/gamepost/controllers/GameController.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/controllers/GameController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import es.codeurjc.gamepost.objects.Description;
 import es.codeurjc.gamepost.objects.Forum;
 import es.codeurjc.gamepost.objects.Game;
+import es.codeurjc.gamepost.objects.enums.Developer;
+import es.codeurjc.gamepost.objects.enums.Genre;
+import es.codeurjc.gamepost.objects.enums.Platform;
+import es.codeurjc.gamepost.objects.enums.Publisher;
 import es.codeurjc.gamepost.repositories.DescriptionRepository;
 import es.codeurjc.gamepost.repositories.GameRepository;
 
@@ -27,9 +31,9 @@ public class GameController {
     //TODO: Associate this method with the form in the web
     @RequestMapping("/submit/Game")
     public String submitGame(Model model, @RequestParam String cover, 
-        @RequestParam String name, @RequestParam List<String> genre, @RequestParam int numPlayers, 
-        @RequestParam Date publishedDate, @RequestParam List<String> platform, 
-        @RequestParam String developer, @RequestParam String publisher, @RequestParam String synopsis){
+        @RequestParam String name, @RequestParam List<Genre> genre, @RequestParam int numPlayers, 
+        @RequestParam Date publishedDate, @RequestParam List<Platform> platform, 
+        @RequestParam Developer developer, @RequestParam Publisher publisher, @RequestParam String synopsis){
         
         Description d = descriptionRepository.save(new Description(
             name, genre, numPlayers, publishedDate, platform, developer, publisher, synopsis

--- a/gamepost/src/main/java/es/codeurjc/gamepost/objects/Description.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/objects/Description.java
@@ -5,7 +5,12 @@ import java.util.List;
 
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
+import es.codeurjc.gamepost.objects.enums.Developer;
+import es.codeurjc.gamepost.objects.enums.Genre;
+import es.codeurjc.gamepost.objects.enums.Platform;
+import es.codeurjc.gamepost.objects.enums.Publisher;
 import javassist.runtime.Desc;
 
 import javax.persistence.Entity;
@@ -22,12 +27,12 @@ public class Description {
     int id;
     
     String name;
-    List<String> genre;
+    @ManyToMany List<Genre> genre;
     int numPlayers;
     Date publishedOn;
-    List<String> platform; 
-    String developper;   
-    String publisher;      
+    @ManyToMany List<Platform> platform; 
+    @ManyToOne Developer developper;   
+    @ManyToOne Publisher publisher;      
     String synopsis;
 
     //#endregion
@@ -36,8 +41,8 @@ public class Description {
 
     public Description(){}
     
-    public Description(String name, List<String> genre, int numPlayers, Date publishedOn, List<String> platform,
-        String developper, String publisher, String synopsis) {
+    public Description(String name, List<Genre> genre, int numPlayers, Date publishedOn, List<Platform> platform,
+        Developer developper, Publisher publisher, String synopsis) {
         this.name = name;
         this.genre = genre;
         this.numPlayers = numPlayers;
@@ -64,11 +69,11 @@ public class Description {
         this.name = name;
     }
 
-    public List<String> getGenre() {
+    public List<Genre> getGenre() {
         return genre;
     }
 
-    public void setGenre(List<String> genre) {
+    public void setGenre(List<Genre> genre) {
         this.genre = genre;
     }
 
@@ -88,27 +93,27 @@ public class Description {
         this.publishedOn = publishedOn;
     }
 
-    public List<String> getPlatform() {
+    public List<Platform> getPlatform() {
         return platform;
     }
 
-    public void setPlatform(List<String> platform) {
+    public void setPlatform(List<Platform> platform) {
         this.platform = platform;
     }
 
-    public String getDevelopper() {
+    public Developer getDevelopper() {
         return developper;
     }
 
-    public void setDevelopper(String developper) {
+    public void setDevelopper(Developer developper) {
         this.developper = developper;
     }
 
-    public String getPublisher() {
+    public Publisher getPublisher() {
         return publisher;
     }
 
-    public void setPublisher(String publisher) {
+    public void setPublisher(Publisher publisher) {
         this.publisher = publisher;
     }
 

--- a/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Developer.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Developer.java
@@ -1,0 +1,21 @@
+package es.codeurjc.gamepost.objects.enums;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Developer{   
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    int id;
+
+    String text;
+
+    public Developer(){}
+    
+    public Developer(String text){
+        this.text = text;
+    }
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Genre.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Genre.java
@@ -1,0 +1,21 @@
+package es.codeurjc.gamepost.objects.enums;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Genre{
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    int id;
+
+    String text;
+
+    public Genre(){}
+    
+    public Genre(String text){
+        this.text = text;
+    }
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Platform.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Platform.java
@@ -1,0 +1,21 @@
+package es.codeurjc.gamepost.objects.enums;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Platform{
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    int id;
+
+    String text;
+
+    public Platform(){}
+    
+    public Platform(String text){
+        this.text = text;
+    }
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Publisher.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/objects/enums/Publisher.java
@@ -1,0 +1,21 @@
+package es.codeurjc.gamepost.objects.enums;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Publisher{
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    int id;
+
+    String text;
+
+    public Publisher(){}
+    
+    public Publisher(String text){
+        this.text = text;
+    }
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/DeveloperRepository.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/DeveloperRepository.java
@@ -1,0 +1,9 @@
+package es.codeurjc.gamepost.repositories.enums;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import es.codeurjc.gamepost.objects.enums.Developer;
+
+public interface DeveloperRepository extends JpaRepository<Developer, Integer>{
+    
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/GenreRepository.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/GenreRepository.java
@@ -1,0 +1,9 @@
+package es.codeurjc.gamepost.repositories.enums;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import es.codeurjc.gamepost.objects.enums.Genre;
+
+public interface GenreRepository extends JpaRepository<Genre, Integer>{
+    
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/PlatformRepository.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/PlatformRepository.java
@@ -1,0 +1,9 @@
+package es.codeurjc.gamepost.repositories.enums;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import es.codeurjc.gamepost.objects.enums.Platform;
+
+public interface PlatformRepository extends JpaRepository<Platform, Integer>{
+    
+}

--- a/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/PublisherRepository.java
+++ b/gamepost/src/main/java/es/codeurjc/gamepost/repositories/enums/PublisherRepository.java
@@ -1,0 +1,9 @@
+package es.codeurjc.gamepost.repositories.enums;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import es.codeurjc.gamepost.objects.enums.Publisher;
+
+public interface PublisherRepository extends JpaRepository<Publisher, Integer>{
+    
+}


### PR DESCRIPTION
We can't do it without a class because a description can contain multiple platforms or genres, so there must be an entity in order to make a table between the two of them.